### PR TITLE
1.19 update tracker

### DIFF
--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/BuildSystem.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/BuildSystem.java
@@ -42,7 +42,6 @@ import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/BuilderInventory.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/inventory/BuilderInventory.java
@@ -15,7 +15,7 @@ import com.eintosti.buildsystem.manager.InventoryManager;
 import com.eintosti.buildsystem.object.world.BuildWorld;
 import com.eintosti.buildsystem.object.world.Builder;
 import com.eintosti.buildsystem.util.UUIDFetcher;
-import org.apache.commons.lang.StringUtils;
+import com.eintosti.buildsystem.util.external.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/InventoryCloseListener.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/InventoryCloseListener.java
@@ -11,7 +11,6 @@ package com.eintosti.buildsystem.listener;
 import com.cryptomorin.xseries.XMaterial;
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.manager.InventoryManager;
-import com.eintosti.buildsystem.manager.WorldManager;
 import com.eintosti.buildsystem.object.world.data.WorldStatus;
 import com.eintosti.buildsystem.object.world.data.WorldType;
 import org.bukkit.event.EventHandler;
@@ -27,12 +26,10 @@ public class InventoryCloseListener implements Listener {
 
     private final BuildSystem plugin;
     private final InventoryManager inventoryManager;
-    private final WorldManager worldManager;
 
     public InventoryCloseListener(BuildSystem plugin) {
         this.plugin = plugin;
         this.inventoryManager = plugin.getInventoryManager();
-        this.worldManager = plugin.getWorldManager();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/SettingsInteractListener.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/SettingsInteractListener.java
@@ -137,10 +137,10 @@ public class SettingsInteractListener implements Listener {
 
         XMaterial xMaterial = XMaterial.matchXMaterial(itemStack.getType());
         if (!XTag.FLOWERS.isTagged(xMaterial)
-                || !XTag.REPLACEABLE_PLANTS.isTagged(xMaterial)
-                || !XTag.ALIVE_CORAL_PLANTS.isTagged(xMaterial)
-                || !XTag.DEAD_CORAL_PLANTS.isTagged(xMaterial)
-                || !XTag.SAPLINGS.isTagged(xMaterial)) {
+                && !XTag.REPLACEABLE_PLANTS.isTagged(xMaterial)
+                && !XTag.ALIVE_CORAL_PLANTS.isTagged(xMaterial)
+                && !XTag.DEAD_CORAL_PLANTS.isTagged(xMaterial)
+                && !XTag.SAPLINGS.isTagged(xMaterial)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/SettingsInteractListener.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/listener/SettingsInteractListener.java
@@ -135,8 +135,12 @@ public class SettingsInteractListener implements Listener {
             return;
         }
 
-        Material material = itemStack.getType();
-        if (!XTag.FLOWERS.isTagged(XMaterial.matchXMaterial(material))) {
+        XMaterial xMaterial = XMaterial.matchXMaterial(itemStack.getType());
+        if (!XTag.FLOWERS.isTagged(xMaterial)
+                || !XTag.REPLACEABLE_PLANTS.isTagged(xMaterial)
+                || !XTag.ALIVE_CORAL_PLANTS.isTagged(xMaterial)
+                || !XTag.DEAD_CORAL_PLANTS.isTagged(xMaterial)
+                || !XTag.SAPLINGS.isTagged(xMaterial)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/InventoryManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/InventoryManager.java
@@ -21,7 +21,7 @@ import com.eintosti.buildsystem.object.world.data.WorldStatus;
 import com.eintosti.buildsystem.object.world.data.WorldType;
 import com.eintosti.buildsystem.util.exception.UnexpectedEnumValueException;
 import com.eintosti.buildsystem.util.external.ItemSkulls;
-import org.apache.commons.lang.StringUtils;
+import com.eintosti.buildsystem.util.external.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/manager/WorldManager.java
@@ -162,13 +162,13 @@ public class WorldManager {
 
         new PlayerChatInput(plugin, player, "enter_world_name", input -> {
             for (String charString : input.split("")) {
-                if (charString.matches("[^A-Za-z0-9/_-]")) {
+                if (charString.matches("[^A-Za-z\\d/_-]")) {
                     player.sendMessage(plugin.getString("worlds_world_creation_invalid_characters"));
                     break;
                 }
             }
 
-            String worldName = input.replaceAll("[^A-Za-z0-9/_-]", "").replace(" ", "_").trim();
+            String worldName = input.replaceAll("[^A-Za-z\\d/_-]", "").replace(" ", "_").trim();
             if (worldName.isEmpty()) {
                 player.sendMessage(plugin.getString("worlds_world_creation_name_bank"));
                 return;
@@ -476,7 +476,7 @@ public class WorldManager {
      */
     public void importWorld(Player player, String worldName, Generator generator, String... generatorName) {
         for (String charString : worldName.split("")) {
-            if (charString.matches("[^A-Za-z0-9/_-]")) {
+            if (charString.matches("[^A-Za-z\\d/_-]")) {
                 player.sendMessage(plugin.getString("worlds_import_invalid_character")
                         .replace("%world%", worldName)
                         .replace("%char%", charString)
@@ -488,6 +488,11 @@ public class WorldManager {
         File file = new File(Bukkit.getWorldContainer(), worldName);
         if (!file.exists() || !file.isDirectory()) {
             player.sendMessage(plugin.getString("worlds_import_unknown_world"));
+            return;
+        }
+
+        if (getBuildWorld(worldName) != null) {
+            player.sendMessage(plugin.getString("worlds_world_exists"));
             return;
         }
 
@@ -547,10 +552,15 @@ public class WorldManager {
 
                 String worldName = worldList[i];
                 for (String charString : worldName.split("")) {
-                    if (charString.matches("[^A-Za-z0-9/_-]")) {
+                    if (charString.matches("[^A-Za-z\\d/_-]")) {
                         player.sendMessage(plugin.getString("worlds_importall_invalid_character").replace("%world%", worldName).replace("%char%", charString));
                         return;
                     }
+                }
+
+                if (getBuildWorld(worldName) != null) {
+                    player.sendMessage(plugin.getString("worlds_importall_world_already_imported").replace("%world%", worldName));
+                    return;
                 }
 
                 long creation = FileUtils.getDirectoryCreation(new File(Bukkit.getWorldContainer(), worldName));
@@ -559,7 +569,7 @@ public class WorldManager {
                 generateBukkitWorld(worldName, WorldType.VOID, buildWorld.getDifficulty());
                 player.sendMessage(plugin.getString("worlds_importall_world_imported").replace("%world%", worldName));
 
-                if (!(worldsImported.get() < worlds)) {
+                if (worldsImported.get() >= worlds) {
                     this.cancel();
                     player.sendMessage(plugin.getString("worlds_importall_finished"));
                 }
@@ -671,14 +681,14 @@ public class WorldManager {
         }
 
         for (String charString : newName.split("")) {
-            if (charString.matches("[^A-Za-z0-9/_-]")) {
+            if (charString.matches("[^A-Za-z\\d/_-]")) {
                 player.sendMessage(plugin.getString("worlds_world_creation_invalid_characters"));
                 break;
             }
         }
 
         player.closeInventory();
-        String parsedNewName = newName.replaceAll("[^A-Za-z0-9/_-]", "").replace(" ", "_").trim();
+        String parsedNewName = newName.replaceAll("[^A-Za-z\\d/_-]", "").replace(" ", "_").trim();
         if (parsedNewName.isEmpty()) {
             player.sendMessage(plugin.getString("worlds_world_creation_name_bank"));
             return;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/object/internal/ServerVersion.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/object/internal/ServerVersion.java
@@ -42,6 +42,7 @@ public enum ServerVersion {
     v1_17_R1(CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
     v1_18_R1(CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
     v1_18_R2(CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
+    v1_19_R1(CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
     UNKNOWN;
 
     private final Class<? extends CustomBlocks> customBlocks;

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/tabcomplete/ArgumentSorter.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/tabcomplete/ArgumentSorter.java
@@ -8,7 +8,7 @@
 
 package com.eintosti.buildsystem.tabcomplete;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/Messages.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/Messages.java
@@ -284,6 +284,7 @@ public class Messages {
         setMessage(sb, config, "worlds_importall_started", "%prefix% &7Beginning import of &b%amount% &7worlds...");
         setMessage(sb, config, "worlds_importall_delay", "%prefix% &8➥ &7Delay between each world: &b%delay%s&7.");
         setMessage(sb, config, "worlds_importall_invalid_character", "%prefix% &c✘ &7&o%world% &7contains invalid character &8(&c%char%&8)");
+        setMessage(sb, config, "worlds_importall_world_already_imported", "%prefix% &c&l✗ &7World already imported: &b%world%");
         setMessage(sb, config, "worlds_importall_world_imported", "%prefix% &a✔ &7World imported: &b%world%");
         setMessage(sb, config, "worlds_importall_finished", "%prefix% &7All worlds have been &asuccessfully &7imported.");
         addLine(sb, "");

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/external/NumberUtils.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/external/NumberUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, Thomas Meaney
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.eintosti.buildsystem.util.external;
+
+/**
+ * <p>Provides extra functionality for Java Number classes.</p>
+ *
+ * @since 2.0
+ */
+public class NumberUtils {
+
+    /**
+     * <p>{@code NumberUtils} instances should NOT be constructed in standard programming.
+     * Instead, the class should be used as {@code NumberUtils.toInt("6");}.</p>
+     *
+     * <p>This constructor is public to permit tools that require a JavaBean instance
+     * to operate.</p>
+     */
+    public NumberUtils() {
+    }
+
+    /**
+     * <p>Convert a {@code String} to an {@code int}, returning
+     * {@code zero} if the conversion fails.</p>
+     *
+     * <p>If the string is {@code null}, {@code zero} is returned.</p>
+     *
+     * <pre>
+     *   NumberUtils.toInt(null) = 0
+     *   NumberUtils.toInt("")   = 0
+     *   NumberUtils.toInt("1")  = 1
+     * </pre>
+     *
+     * @param str the string to convert, may be null
+     * @return the int represented by the string, or {@code zero} if
+     * conversion fails
+     * @since 2.1
+     */
+    public static int toInt(final String str) {
+        return toInt(str, 0);
+    }
+
+    /**
+     * <p>Convert a {@code String} to an {@code int}, returning a
+     * default value if the conversion fails.</p>
+     *
+     * <p>If the string is {@code null}, the default value is returned.</p>
+     *
+     * <pre>
+     *   NumberUtils.toInt(null, 1) = 1
+     *   NumberUtils.toInt("", 1)   = 1
+     *   NumberUtils.toInt("1", 0)  = 1
+     * </pre>
+     *
+     * @param str          the string to convert, may be null
+     * @param defaultValue the default value
+     * @return the int represented by the string, or the default if conversion fails
+     * @since 2.1
+     */
+    public static int toInt(final String str, final int defaultValue) {
+        if (str == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(str);
+        } catch (final NumberFormatException nfe) {
+            return defaultValue;
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/external/StringUtils.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/external/StringUtils.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022, Thomas Meaney
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.eintosti.buildsystem.util.external;
+
+/**
+ * <p>Operations on {@link java.lang.String} that are
+ * {@code null} safe.</p>
+ *
+ * <ul>
+ *  <li><b>Difference</b>
+ *      - compares Strings and reports on their differences</li>
+ * </ul>
+ *
+ * <p>The {@code StringUtils} class defines certain words related to
+ * String handling.</p>
+ *
+ * <ul>
+ *  <li>null - {@code null}</li>
+ *  <li>empty - a zero-length string ({@code ""})</li>
+ *  <li>space - the space character ({@code ' '}, char 32)</li>
+ *  <li>whitespace - the characters defined by {@link Character#isWhitespace(char)}</li>
+ *  <li>trim - the characters &lt;= 32 as in {@link String#trim()}</li>
+ * </ul>
+ *
+ * <p>{@code StringUtils} handles {@code null} input Strings quietly.
+ * That is to say that a {@code null} input will return {@code null}.
+ * Where a {@code boolean} or {@code int} is being returned
+ * details vary by method.</p>
+ *
+ * <p>A side effect of the {@code null} handling is that a
+ * {@code NullPointerException} should be considered a bug in
+ * {@code StringUtils}.</p>
+ *
+ * <p>Methods in this class include sample code in their Javadoc comments to explain their operation.
+ * The symbol {@code *} is used to indicate any input including {@code null}.</p>
+ *
+ * <p>#ThreadSafe#</p>
+ *
+ * @see java.lang.String
+ * @since 1.0
+ */
+//@Immutable
+public class StringUtils {
+
+    /**
+     * The empty String {@code ""}.
+     *
+     * @since 2.0
+     */
+    public static final String EMPTY = "";
+
+    /**
+     * Represents a failed index search.
+     *
+     * @since 2.1
+     */
+    public static final int INDEX_NOT_FOUND = -1;
+
+    /**
+     * <p>Compares two Strings, and returns the portion where they differ.
+     * More precisely, return the remainder of the second String,
+     * starting from where it's different from the first. This means that
+     * the difference between "abc" and "ab" is the empty String and not "c". </p>
+     *
+     * <p>For example,
+     * {@code difference("i am a machine", "i am a robot") -> "robot"}.</p>
+     *
+     * <pre>
+     * StringUtils.difference(null, null) = null
+     * StringUtils.difference("", "") = ""
+     * StringUtils.difference("", "abc") = "abc"
+     * StringUtils.difference("abc", "") = ""
+     * StringUtils.difference("abc", "abc") = ""
+     * StringUtils.difference("abc", "ab") = ""
+     * StringUtils.difference("ab", "abxyz") = "xyz"
+     * StringUtils.difference("abcde", "abxyz") = "xyz"
+     * StringUtils.difference("abcde", "xyz") = "xyz"
+     * </pre>
+     *
+     * @param str1 the first String, may be null
+     * @param str2 the second String, may be null
+     * @return the portion of str2 where it differs from str1; returns the
+     * empty String if they are equal
+     * @see #indexOfDifference(CharSequence, CharSequence)
+     * @since 2.0
+     */
+    public static String difference(final String str1, final String str2) {
+        if (str1 == null) {
+            return str2;
+        }
+        if (str2 == null) {
+            return str1;
+        }
+        final int at = indexOfDifference(str1, str2);
+        if (at == INDEX_NOT_FOUND) {
+            return EMPTY;
+        }
+        return str2.substring(at);
+    }
+
+    /**
+     * <p>Compares two CharSequences, and returns the index at which the
+     * CharSequences begin to differ.</p>
+     *
+     * <p>For example,
+     * {@code indexOfDifference("i am a machine", "i am a robot") -> 7}</p>
+     *
+     * <pre>
+     * StringUtils.indexOfDifference(null, null) = -1
+     * StringUtils.indexOfDifference("", "") = -1
+     * StringUtils.indexOfDifference("", "abc") = 0
+     * StringUtils.indexOfDifference("abc", "") = 0
+     * StringUtils.indexOfDifference("abc", "abc") = -1
+     * StringUtils.indexOfDifference("ab", "abxyz") = 2
+     * StringUtils.indexOfDifference("abcde", "abxyz") = 2
+     * StringUtils.indexOfDifference("abcde", "xyz") = 0
+     * </pre>
+     *
+     * @param cs1 the first CharSequence, may be null
+     * @param cs2 the second CharSequence, may be null
+     * @return the index where cs1 and cs2 begin to differ; -1 if they are equal
+     * @since 2.0
+     * @since 3.0 Changed signature from indexOfDifference(String, String) to
+     * indexOfDifference(CharSequence, CharSequence)
+     */
+    public static int indexOfDifference(final CharSequence cs1, final CharSequence cs2) {
+        if (cs1 == cs2) {
+            return INDEX_NOT_FOUND;
+        }
+        if (cs1 == null || cs2 == null) {
+            return 0;
+        }
+        int i;
+        for (i = 0; i < cs1.length() && i < cs2.length(); ++i) {
+            if (cs1.charAt(i) != cs2.charAt(i)) {
+                break;
+            }
+        }
+        if (i < cs2.length() || i < cs1.length()) {
+            return i;
+        }
+        return INDEX_NOT_FOUND;
+    }
+}

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/external/UpdateChecker.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/util/external/UpdateChecker.java
@@ -12,7 +12,6 @@ import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
-import org.apache.commons.lang.math.NumberUtils;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.eintosti
-version=2.19
+version=2.20
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ annotations = "23.0.0"
 authlib = "1.5.25"
 bstats = "3.0.0"
 fastboard = "1.2.1"
-xseries = "8.7.1"
+xseries = "8.8.0"
 
 [libraries]
 #Platform expectations

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Platform expectations
-spigot = "1.18.2-R0.1-SNAPSHOT"
+spigot = "1.19-R0.1-SNAPSHOT"
 
 # Plugins
 luckperms = "5.4"


### PR DESCRIPTION
> This acts as a tracker for what will be needed to do for the 1.19 update.

- [x] Wait for Minecraft 1.19 release (07.06.2022)
- [x] Wait for Spigot 1.18 full release
- [x] Wait for [XSeries](https://github.com/CryptoMorin/XSeries) to add the new blocks added in 1.19
- [x] Make sure nothing breaks internally (especially in older versions) when updating to 1.19

Optional: 
- [ ] Wait for [FastBoard](https://github.com/MrMicky-FR/FastBoard) to add support for 1.19 (Seems to work atm, but it is not officially supported)
