### PR TITLE
Check world `DataVersion` before loading

### DIFF
--- a/buildsystem-abstraction/adapter-1_12/build.gradle.kts
+++ b/buildsystem-abstraction/adapter-1_12/build.gradle.kts
@@ -1,7 +1,7 @@
 applyAdapterConfiguration()
 
 plugins {
-    java
+    `java-library`
 }
 
 dependencies {

--- a/buildsystem-abstraction/adapter-1_13/build.gradle.kts
+++ b/buildsystem-abstraction/adapter-1_13/build.gradle.kts
@@ -1,7 +1,7 @@
 applyAdapterConfiguration()
 
 plugins {
-    java
+    `java-library`
 }
 
 dependencies {

--- a/buildsystem-abstraction/adapter-1_14/build.gradle.kts
+++ b/buildsystem-abstraction/adapter-1_14/build.gradle.kts
@@ -1,7 +1,7 @@
 applyAdapterConfiguration()
 
 plugins {
-    java
+    `java-library`
 }
 
 dependencies {

--- a/buildsystem-abstraction/adapter-1_17/build.gradle.kts
+++ b/buildsystem-abstraction/adapter-1_17/build.gradle.kts
@@ -1,7 +1,7 @@
 applyAdapterConfiguration()
 
 plugins {
-    java
+    `java-library`
 }
 
 dependencies {

--- a/buildsystem-abstraction/common/build.gradle.kts
+++ b/buildsystem-abstraction/common/build.gradle.kts
@@ -1,7 +1,7 @@
 applyCommonConfiguration()
 
 plugins {
-    java
+    `java-library`
 }
 
 dependencies {

--- a/buildsystem-core/build.gradle.kts
+++ b/buildsystem-core/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.paperlib)
     implementation(libs.xseries)
     implementation(libs.fastboard)
+    implementation(libs.nbt) { isTransitive = false }
     implementation(libs.bstats)
 }
 
@@ -49,24 +50,20 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-    javadoc {
-        options.encoding = Charsets.UTF_8.name()
-    }
-    processResources {
-        filteringCharset = Charsets.UTF_8.name()
-    }
 
     shadowJar {
         dependsOn(project.project(":buildsystem-abstraction").subprojects.map {
             it.tasks.named("assemble")
         })
 
+        minimize()
         archiveFileName.set("${rootProject.name}-${project.version}.jar")
 
         val shadePath = "com.eintosti.buildsystem.util.external"
         relocate("io.papermc.lib", "$shadePath.paperlib")
         relocate("com.cryptomorin.xseries", "$shadePath.xseries")
         relocate("fr.mrmicky.fastboard", "$shadePath.fastboard")
+        relocate("dev.dewy.nbt", "$shadePath.nbt")
         relocate("org.bstats", "$shadePath.bstats")
     }
 

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/BuildSystem.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/BuildSystem.java
@@ -88,7 +88,8 @@ public class BuildSystem extends JavaPlugin {
     public static final int METRICS_ID = 7427;
     public static final String ADMIN_PERMISSION = "buildsystem.admin";
 
-    private String version;
+    private String versionString;
+    private ServerVersion serverVersion;
 
     private ArmorStandManager armorStandManager;
     private InventoryUtil inventoryUtil;
@@ -137,7 +138,7 @@ public class BuildSystem extends JavaPlugin {
 
         initClasses();
         if (!initVersionedClasses()) {
-            getLogger().severe("BuildSystem does not support your server version: " + version);
+            getLogger().severe("BuildSystem does not support your server version: " + versionString);
             getLogger().severe("Disabling plugin...");
             this.setEnabled(false);
             return;
@@ -195,7 +196,7 @@ public class BuildSystem extends JavaPlugin {
     }
 
     private boolean initVersionedClasses() {
-        ServerVersion serverVersion = ServerVersion.matchServerVersion(version);
+        this.serverVersion = ServerVersion.matchServerVersion(versionString);
         if (serverVersion == ServerVersion.UNKNOWN) {
             return false;
         }
@@ -233,13 +234,13 @@ public class BuildSystem extends JavaPlugin {
         this.statusInventory = new StatusInventory(this);
         this.worldsInventory = new WorldsInventory(this);
 
-        this.skullCache = new SkullCache(version);
+        this.skullCache = new SkullCache(versionString);
     }
 
     private void parseServerVersion() {
         try {
-            this.version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-            getLogger().info("Detected server version: " + version);
+            this.versionString = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+            getLogger().info("Detected server version: " + versionString);
         } catch (ArrayIndexOutOfBoundsException e) {
             getLogger().severe("Unknown server version");
         }
@@ -397,6 +398,10 @@ public class BuildSystem extends JavaPlugin {
                 getSettingsManager().stopScoreboard();
             }
         }
+    }
+
+    public ServerVersion getServerVersion() {
+        return serverVersion;
     }
 
     public ArmorStandManager getArmorStandManager() {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/Messages.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/Messages.java
@@ -277,6 +277,7 @@ public class Messages {
         setMessage(sb, "worlds_import_unknown_world", "%prefix% &cUnknown world.");
         setMessage(sb, "worlds_import_world_is_imported", "%prefix% &7This world is already imported.");
         setMessage(sb, "worlds_import_unknown_generator", "%prefix% &cUnknown generator.");
+        setMessage(sb, "worlds_import_newer_version", "%prefix% &b%world% &7was created in a &cnewer version &7of Minecraft. Unable to import.");
         setMessage(sb, "worlds_import_started", "%prefix% &7The import of &b%world% &7has started...");
         setMessage(sb, "worlds_import_invalid_character", "%prefix% &7Unable to import &c%world%&7.\n" +
                 "%prefix% &7&oName contains invalid character: &c%char%");
@@ -288,6 +289,7 @@ public class Messages {
         setMessage(sb, "worlds_importall_delay", "%prefix% &8➥ &7Delay between each world: &b%delay%s&7.");
         setMessage(sb, "worlds_importall_invalid_character", "%prefix% &c✘ &7&o%world% &7contains invalid character &8(&c%char%&8)");
         setMessage(sb, "worlds_importall_world_already_imported", "%prefix% &c&l✗ &7World already imported: &b%world%");
+        setMessage(sb, "worlds_import_newer_version", "%prefix% &c&l✗ &b%world% &7was created in a &cnewer version &7of Minecraft");
         setMessage(sb, "worlds_importall_world_imported", "%prefix% &a✔ &7World imported: &b%world%");
         setMessage(sb, "worlds_importall_finished", "%prefix% &7All worlds have been &asuccessfully &7imported.");
         addSpacer(sb, "");

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/config/WorldConfig.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/config/WorldConfig.java
@@ -12,7 +12,9 @@ import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.world.BuildWorld;
 import com.eintosti.buildsystem.world.BuildWorldCreator;
 import com.eintosti.buildsystem.world.WorldManager;
+import org.bukkit.World;
 
+import java.util.Iterator;
 import java.util.logging.Logger;
 
 /**
@@ -40,16 +42,22 @@ public class WorldConfig extends ConfigurationFile {
         }
 
         logger.info("*** All worlds will be loaded now ***");
-        worldManager.getBuildWorlds().forEach(world -> {
-            String worldName = world.getName();
-            new BuildWorldCreator(plugin, world).generateBukkitWorld();
+        Iterator<BuildWorld> iterator = worldManager.getBuildWorlds().iterator();
+        while (iterator.hasNext()) {
+            BuildWorld buildWorld = iterator.next();
+            String worldName = buildWorld.getName();
+            World world = new BuildWorldCreator(plugin, buildWorld).generateBukkitWorld();
+            if (world == null) {
+                iterator.remove();
+                continue;
+            }
 
-            if (world.getMaterial() == XMaterial.PLAYER_HEAD) {
+            if (buildWorld.getMaterial() == XMaterial.PLAYER_HEAD) {
                 plugin.getSkullCache().cacheSkull(worldName);
             }
 
             logger.info("✔ World loaded: " + worldName);
-        });
+        }
         logger.info("*** All worlds have been loaded ***");
     }
 }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/internal/ServerVersion.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/internal/ServerVersion.java
@@ -47,20 +47,20 @@ public enum ServerVersion {
     v1_19_R1(3120, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
     UNKNOWN;
 
-    private final int worldVersion;
+    private final int dataVersion;
     private final Class<? extends CustomBlocks> customBlocks;
     private final Class<? extends GameRules> gameRules;
 
     private final BuildSystem plugin = JavaPlugin.getPlugin(BuildSystem.class);
 
-    ServerVersion(int worldVersion, Class<? extends CustomBlocks> customBlocks, Class<? extends GameRules> gameRules) {
-        this.worldVersion = worldVersion;
+    ServerVersion(int dataVersion, Class<? extends CustomBlocks> customBlocks, Class<? extends GameRules> gameRules) {
+        this.dataVersion = dataVersion;
         this.customBlocks = customBlocks;
         this.gameRules = gameRules;
     }
 
     ServerVersion() {
-        this.worldVersion = -1;
+        this.dataVersion = -1;
         this.customBlocks = null;
         this.gameRules = null;
     }
@@ -73,8 +73,8 @@ public enum ServerVersion {
         }
     }
 
-    public int getWorldVersion() {
-        return worldVersion;
+    public int getDataVersion() {
+        return dataVersion;
     }
 
     public CustomBlocks initCustomBlocks() {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/internal/ServerVersion.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/internal/ServerVersion.java
@@ -26,23 +26,23 @@ import java.util.List;
  * @author einTosti
  */
 public enum ServerVersion {
-    v1_8_R1(47, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_8_R2(47, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_8_R3(47, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_9_R1(107, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_9_R2(109, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_10_R1(210, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_11_R1(316, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_12_R1(340, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_13_R1(393, CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
-    v1_13_R2(404, CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
-    v1_14_R1(498, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_15_R1(578, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_16_R1(736, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_16_R2(753, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_16_R3(754, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_17_R1(756, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
-    v1_18_R1(757, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
+    v1_8_R1(-1, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_8_R2(-1, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_8_R3(-1, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_9_R1(169, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_9_R2(184, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_10_R1(512, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_11_R1(922, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_12_R1(1343, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_13_R1(1519, CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
+    v1_13_R2(1631, CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
+    v1_14_R1(1976, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_15_R1(2230, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_16_R1(2567, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_16_R2(2580, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_16_R3(2586, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_17_R1(2730, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
+    v1_18_R1(2865, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
     v1_18_R2(2975, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
     v1_19_R1(3120, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
     UNKNOWN;
@@ -73,6 +73,15 @@ public enum ServerVersion {
         }
     }
 
+    /**
+     * Gets the server's data version.
+     * <p>
+     * "The data version is a positive integer used in a world saved data to denote a specific version, and determines
+     * whether the player should be warned about opening that world due to client version incompatibilities."
+     *
+     * @return The server's data version
+     * @see <a href="https://minecraft.fandom.com/wiki/Data_version">Data version</a>
+     */
     public int getDataVersion() {
         return dataVersion;
     }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/internal/ServerVersion.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/internal/ServerVersion.java
@@ -26,38 +26,41 @@ import java.util.List;
  * @author einTosti
  */
 public enum ServerVersion {
-    v1_8_R1(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_8_R2(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_8_R3(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_9_R1(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_9_R2(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_10_R1(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_11_R1(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_12_R1(CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
-    v1_13_R1(CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
-    v1_13_R2(CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
-    v1_14_R1(CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_15_R1(CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_16_R1(CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_16_R2(CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_16_R3(CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
-    v1_17_R1(CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
-    v1_18_R1(CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
-    v1_18_R2(CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
-    v1_19_R1(CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
+    v1_8_R1(47, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_8_R2(47, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_8_R3(47, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_9_R1(107, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_9_R2(109, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_10_R1(210, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_11_R1(316, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_12_R1(340, CustomBlocks_1_12_R1.class, GameRules_1_12_R1.class),
+    v1_13_R1(393, CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
+    v1_13_R2(404, CustomBlocks_1_13_R1.class, GameRules_1_13_R1.class),
+    v1_14_R1(498, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_15_R1(578, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_16_R1(736, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_16_R2(753, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_16_R3(754, CustomBlocks_1_14_R1.class, GameRules_1_13_R1.class),
+    v1_17_R1(756, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
+    v1_18_R1(757, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
+    v1_18_R2(2975, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
+    v1_19_R1(3120, CustomBlocks_1_17_R1.class, GameRules_1_13_R1.class),
     UNKNOWN;
 
+    private final int worldVersion;
     private final Class<? extends CustomBlocks> customBlocks;
     private final Class<? extends GameRules> gameRules;
 
     private final BuildSystem plugin = JavaPlugin.getPlugin(BuildSystem.class);
 
-    ServerVersion(Class<? extends CustomBlocks> customBlocks, Class<? extends GameRules> gameRules) {
+    ServerVersion(int worldVersion, Class<? extends CustomBlocks> customBlocks, Class<? extends GameRules> gameRules) {
+        this.worldVersion = worldVersion;
         this.customBlocks = customBlocks;
         this.gameRules = gameRules;
     }
 
     ServerVersion() {
+        this.worldVersion = -1;
         this.customBlocks = null;
         this.gameRules = null;
     }
@@ -68,6 +71,10 @@ public enum ServerVersion {
         } catch (IllegalArgumentException e) {
             return UNKNOWN;
         }
+    }
+
+    public int getWorldVersion() {
+        return worldVersion;
     }
 
     public CustomBlocks initCustomBlocks() {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/BuildWorldCreator.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/BuildWorldCreator.java
@@ -362,10 +362,10 @@ public class BuildWorldCreator {
     /**
      * Parses the world's data version, as stored in {@code level.dat}.
      *
-     * @return The world's data version
+     * @return The world's data version if found, otherwise -1 if unable to parse
      * @see <a href="https://minecraft.fandom.com/wiki/Data_version">Data version</a>
      */
-    private int parseDataVersion() {
+    public int parseDataVersion() {
         File levelFile = new File(Bukkit.getWorldContainer() + File.separator + worldName, "level.dat");
         if (!levelFile.exists()) {
             return -1;
@@ -374,7 +374,9 @@ public class BuildWorldCreator {
         try {
             CompoundTag level = new Nbt().fromFile(levelFile);
             CompoundTag data = level.get("Data");
-            return data.getInt("DataVersion").getValue();
+            IntTag dataVersion = data.getInt("DataVersion");
+
+            return dataVersion != null ? dataVersion.getValue() : -1;
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/BuildWorldCreator.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/BuildWorldCreator.java
@@ -18,17 +18,17 @@ import com.eintosti.buildsystem.world.data.WorldType;
 import com.eintosti.buildsystem.world.generator.CustomGenerator;
 import com.eintosti.buildsystem.world.generator.voidgenerator.DeprecatedVoidGenerator;
 import com.eintosti.buildsystem.world.generator.voidgenerator.ModernVoidGenerator;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Difficulty;
-import org.bukkit.Material;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
+import dev.dewy.nbt.Nbt;
+import dev.dewy.nbt.tags.collection.CompoundTag;
+import dev.dewy.nbt.tags.primitive.IntTag;
+import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.AbstractMap;
 
 /**
@@ -255,6 +255,9 @@ public class BuildWorldCreator {
     private void finishPreparationsAndGenerate(BuildWorld buildWorld) {
         WorldType worldType = buildWorld.getType();
         World bukkitWorld = generateBukkitWorld();
+        if (bukkitWorld == null) {
+            return;
+        }
 
         switch (worldType) {
             case VOID:
@@ -272,12 +275,28 @@ public class BuildWorldCreator {
         }
     }
 
+    @Nullable
+    public World generateBukkitWorld() {
+        return generateBukkitWorld(true);
+    }
+
     /**
      * Generate the {@link World} linked to a {@link BuildWorld}.
      *
+     * @param checkVersion Should the world version be checked
      * @return The world object
      */
-    public World generateBukkitWorld() {
+    @Nullable
+    public World generateBukkitWorld(boolean checkVersion) {
+        if (checkVersion && !Boolean.getBoolean("Paper.ignoreWorldDataVersion")) {
+            int worldVersion = parseWorldDataVersion();
+            int serverVersion = plugin.getServerVersion().getWorldVersion();
+            if (worldVersion > serverVersion) {
+                plugin.getLogger().warning(String.format("\"%s\" was created in a newer version of Minecraft (%s > %s). Skipping...", worldName, worldVersion, serverVersion));
+                return null;
+            }
+        }
+
         WorldCreator worldCreator = new WorldCreator(worldName);
         org.bukkit.WorldType bukkitWorldType;
 
@@ -336,7 +355,47 @@ public class BuildWorldCreator {
             configValues.getDefaultGameRules().forEach(bukkitWorld::setGameRuleValue);
         }
 
+        updateWorldDataVersion();
         return bukkitWorld;
+    }
+
+    private int parseWorldDataVersion() {
+        File levelFile = new File(Bukkit.getWorldContainer() + File.separator + worldName, "level.dat");
+        if (!levelFile.exists()) {
+            return -1;
+        }
+
+        try {
+            CompoundTag level = new Nbt().fromFile(levelFile);
+            CompoundTag data = level.get("Data");
+            return data.getInt("DataVersion").getValue();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return -1;
+    }
+
+    private void updateWorldDataVersion() {
+        File levelFile = new File(Bukkit.getWorldContainer() + File.separator + worldName, "level.dat");
+        if (!levelFile.exists()) {
+            return;
+        }
+
+        try {
+            Nbt nbt = new Nbt();
+            CompoundTag level = nbt.fromFile(levelFile);
+            CompoundTag data = level.get("Data");
+            IntTag dataVersion = data.getInt("DataVersion");
+
+            int serverVersion = plugin.getServerVersion().getWorldVersion();
+            if (dataVersion.getValue() < serverVersion) {
+                dataVersion.setValue(serverVersion);
+                nbt.toFile(level, levelFile);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private void teleportAfterCreation(Player player) {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/BuildWorldCreator.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/BuildWorldCreator.java
@@ -289,8 +289,8 @@ public class BuildWorldCreator {
     @Nullable
     public World generateBukkitWorld(boolean checkVersion) {
         if (checkVersion && !Boolean.getBoolean("Paper.ignoreWorldDataVersion")) {
-            int worldVersion = parseWorldDataVersion();
-            int serverVersion = plugin.getServerVersion().getWorldVersion();
+            int worldVersion = parseDataVersion();
+            int serverVersion = plugin.getServerVersion().getDataVersion();
             if (worldVersion > serverVersion) {
                 plugin.getLogger().warning(String.format("\"%s\" was created in a newer version of Minecraft (%s > %s). Skipping...", worldName, worldVersion, serverVersion));
                 return null;
@@ -355,11 +355,17 @@ public class BuildWorldCreator {
             configValues.getDefaultGameRules().forEach(bukkitWorld::setGameRuleValue);
         }
 
-        updateWorldDataVersion();
+        updateDataVersion();
         return bukkitWorld;
     }
 
-    private int parseWorldDataVersion() {
+    /**
+     * Parses the world's data version, as stored in {@code level.dat}.
+     *
+     * @return The world's data version
+     * @see <a href="https://minecraft.fandom.com/wiki/Data_version">Data version</a>
+     */
+    private int parseDataVersion() {
         File levelFile = new File(Bukkit.getWorldContainer() + File.separator + worldName, "level.dat");
         if (!levelFile.exists()) {
             return -1;
@@ -376,7 +382,11 @@ public class BuildWorldCreator {
         return -1;
     }
 
-    private void updateWorldDataVersion() {
+    /**
+     * The {@code level.dat} file is not updated when a newer Minecraft version loads chunks, making the world not loadable.
+     * Therefore, manually sets the world's {@code DataVersion} to the current server version, if lower.
+     */
+    private void updateDataVersion() {
         File levelFile = new File(Bukkit.getWorldContainer() + File.separator + worldName, "level.dat");
         if (!levelFile.exists()) {
             return;
@@ -388,7 +398,7 @@ public class BuildWorldCreator {
             CompoundTag data = level.get("Data");
             IntTag dataVersion = data.getInt("DataVersion");
 
-            int serverVersion = plugin.getServerVersion().getWorldVersion();
+            int serverVersion = plugin.getServerVersion().getDataVersion();
             if (dataVersion.getValue() < serverVersion) {
                 dataVersion.setValue(serverVersion);
                 nbt.toFile(level, levelFile);

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/SpawnManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/SpawnManager.java
@@ -10,7 +10,6 @@ package com.eintosti.buildsystem.world;
 import com.cryptomorin.xseries.messages.Titles;
 import com.eintosti.buildsystem.BuildSystem;
 import com.eintosti.buildsystem.config.SpawnConfig;
-import com.eintosti.buildsystem.world.data.WorldType;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -18,13 +17,12 @@ import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
-import java.util.UUID;
-
 /**
  * @author einTosti
  */
 public class SpawnManager {
 
+    private final BuildSystem plugin;
     private final WorldManager worldManager;
     private final SpawnConfig spawnConfig;
 
@@ -32,6 +30,7 @@ public class SpawnManager {
     private Location spawn;
 
     public SpawnManager(BuildSystem plugin) {
+        this.plugin = plugin;
         this.worldManager = plugin.getWorldManager();
         this.spawnConfig = new SpawnConfig(plugin);
     }
@@ -102,10 +101,11 @@ public class SpawnManager {
 
         BuildWorld buildWorld = worldManager.getBuildWorld(worldName);
         if (buildWorld == null) {
-            buildWorld = new BuildWorld(worldName, "", UUID.randomUUID(), WorldType.UNKNOWN, System.currentTimeMillis(), false, null);
+            plugin.getLogger().warning("Could load spawn world \"" + worldName + "\". Please check logs for possible errors.");
+            return;
         }
-        buildWorld.load();
 
+        buildWorld.load();
         this.spawnName = worldName;
         this.spawn = new Location(Bukkit.getWorld(worldName), x, y, z, yaw, pitch);
     }

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/WorldManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/WorldManager.java
@@ -483,7 +483,7 @@ public class WorldManager {
             FileUtils.deleteDirectory(oldWorldFile);
 
             buildWorld.setName(parsedNewName);
-            World newWorld = new BuildWorldCreator(plugin, buildWorld).generateBukkitWorld();
+            World newWorld = new BuildWorldCreator(plugin, buildWorld).generateBukkitWorld(false);
             Location spawnLocation = oldWorld.getSpawnLocation();
             spawnLocation.setWorld(newWorld);
 
@@ -656,10 +656,10 @@ public class WorldManager {
         worldConfig.loadWorlds(this);
     }
 
-    public BuildWorld loadWorld(String worldName) {
+    public void loadWorld(String worldName) {
         FileConfiguration configuration = worldConfig.getFile();
         if (configuration == null) {
-            return null;
+            return;
         }
 
         String creator = configuration.isString("worlds." + worldName + ".creator") ? configuration.getString("worlds." + worldName + ".creator") : "-";
@@ -684,7 +684,7 @@ public class WorldManager {
         String generatorName = configuration.getString("worlds." + worldName + ".chunk-generator");
         CustomGenerator customGenerator = new CustomGenerator(generatorName, parseChunkGenerator(worldName, generatorName));
 
-        BuildWorld buildWorld = new BuildWorld(
+        this.buildWorlds.add(new BuildWorld(
                 worldName,
                 creator,
                 creatorId,
@@ -706,10 +706,7 @@ public class WorldManager {
                 difficulty,
                 builders,
                 customGenerator
-        );
-
-        buildWorlds.add(buildWorld);
-        return buildWorld;
+        ));
     }
 
     private XMaterial parseMaterial(FileConfiguration configuration, String worldName) {

--- a/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/WorldManager.java
+++ b/buildsystem-core/src/main/java/com/eintosti/buildsystem/world/WorldManager.java
@@ -340,7 +340,7 @@ public class WorldManager {
                 }
 
                 buildWorlds.add(buildWorld);
-                worldCreator.generateBukkitWorld();
+                worldCreator.setType(WorldType.VOID).generateBukkitWorld();
                 Messages.sendMessage(player, "worlds_importall_world_imported", new AbstractMap.SimpleEntry<>("%world%", worldName));
 
                 if (worldsImported.get() >= worlds) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ annotations = "23.0.0"
 authlib = "1.5.25"
 bstats = "3.0.0"
 fastboard = "1.2.1"
+nbt = "1.5.1"
 xseries = "9.1.0"
 
 [libraries]
@@ -30,4 +31,5 @@ annotations = { group = "org.jetbrains", name = "annotations", version.ref = "an
 authlib = { group = "com.mojang", name = "authlib", version.ref = "authlib" }
 bstats = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bstats" }
 fastboard = { group = "fr.mrmicky", name = "fastboard", version.ref = "fastboard" }
+nbt = { group = "dev.dewy", name = "nbt", version.ref = "nbt" }
 xseries = { group = "com.github.cryptomorin", name = "XSeries", version.ref = "xseries" }


### PR DESCRIPTION
- Stops newer worlds from being loaded in older versions
- Is ignored when `Paper.ignoreWorldDataVersion` is enabled